### PR TITLE
fix: correct the stale Fall 2025 date in the FAQ and dashboard

### DIFF
--- a/app/dashboard/components/profileHeader.tsx
+++ b/app/dashboard/components/profileHeader.tsx
@@ -413,11 +413,11 @@ export default function ProfileHeader(props: {
               <>
                 <CardTitle>
                   Get ready to code! You&apos;re fully signed up and ready to
-                  show up on October 4th.
+                  show up on October 10th.
                 </CardTitle>
                 <CardDescription>
                   Get ready to code! You&apos;re fully signed up and ready to
-                  show up on October 4th. You are guarenteed entry if you show
+                  show up on October 10th. You are guarenteed entry if you show
                   up before 10:30am, at which point it will be first come first
                   served.
                 </CardDescription>

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -18,7 +18,7 @@ export const hackRUFAQ = {
 
   Coming: Thanks for letting us know you can make it! We're slowly moving hackers into the final confirmation stage based on FCFS responses.
 
-  Confirmed: Get ready to code! You're fully signed up and ready to show up on October 4th.
+  Confirmed: Get ready to code! You're fully signed up and ready to show up on October 10th.
 
   Delayed Entry Waitlist: Unfortunately, we've had to place you on our waitlist. Show up closer to our delayed check-in phase where hackers will be checked in based on remaining availability! In the meantime, any confirmed teammates can wait in the venue.
   `,


### PR DESCRIPTION
# What was done

* Changed **October 4th** to **October 10th** in the FAQ's `Confirmed` hacker stage, in `app/lib/constants.ts`
* Changed the same sentence in the dashboard's confirmed-status card, in `app/dashboard/components/profileHeader.tsx`, where it appears in both the `CardTitle` and the `CardDescription`

# Why

Both strings still carried the **Fall 2025** date. `About.tsx` states the event is on **October 10-11 at the Busch Student Center**, so the FAQ contradicted the same page it renders on, and the dashboard told confirmed hackers to show up on the wrong day.

The sentence is duplicated because `profileHeader.tsx` hardcodes its own copy rather than reading from `hackRUFAQ`.

# Not included

* `sections/Hero/Hero.tsx` still reads `October 4th - 5th, College Ave Student Center`. That file is not rendered, `page.tsx` imports `Hero` but renders `Hero2`, and it also disagrees with `About.tsx` on the venue, so it is a content question rather than a typo.
* `offseason/page.tsx` has the old date inside a commented-out block.
